### PR TITLE
Parse Headers with Iterator when `.raw` is not available

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,6 +52,18 @@ function hashCode(str) {
   return hash
 }
 
+function parseHeader(headers) {
+  if (headers.raw) return headers.raw();
+  var raw = {};
+  var itr = headers.entries()
+  var next = itr.next();
+  while (!next.done) {
+    raw[next.value[0]] = next.value[1];
+    next = itr.next();
+  }
+  return raw;
+}
+
 function buildHash(url, args) {
   var json = {}
   if (args) {
@@ -149,8 +161,9 @@ function saveFixture(url, args, response) {
       status: response.status,
       statusText: response.statusText,
       ok: response.ok,
-      headers: response.headers.raw()
+      headers: parseHeader(response.headers),
     }
+
     var optionsRaw = JSON.stringify(json)
 
     return Promise.all([fetchVCR.saveFile(root, bodyFilename, bodyBuffer), fetchVCR.saveFile(root, optionsFilename, optionsRaw) /*, fetchVCR.saveFile(root, requestFilename, JSON.stringify(args || {})) */]).then(function () {


### PR DESCRIPTION
I have this issue when working with `fetch` from `create-react-app`.