### PR TITLE
Configurable ignore urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,28 @@ fetch('http://openstax.org')
 })
 ```
 
+## How do I ignore calls?
+
+Here is how you would configure it to ignore certain request:
+
+```js
+// import fetch from 'fetch';
+import fetch from 'fetch-vcr';
+
+// Configure where the recordings should be loaded/saved to.
+// The path is relative to `process.cwd()` but can be absolute.
+fetch.configure({
+  fixturePath: './_fixtures',
+  ignoreUrls: [/.+weedmaps\.com.+/] // <-- This is an array of Regular Expressions
+  // mode: 'record'     <-- This is optional
+})
+
+fetch('https://weedmaps.com/sitemap') // <-- This will be ignored from vcr
+.then(response => {
+  console.log(response)
+})
+```
+
 ## Jest Setup
 
 Just add the following to `package.json`:

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,8 @@ var DEBUG = typeof process !== 'undefined' ? process.env['DEBUG'] : false
 var CONFIGURATION = {
   mode: VCR_MODE,
   fixturePath: './_fixtures',
-  headerBlacklist: ['authorization', 'user-agent'] // These need to be lowercase
+  headerBlacklist: ['authorization', 'user-agent'], // These need to be lowercase
+  ignoreUrls: [] // regex of urls to ignore
 }
 
 function debug(url, message) {
@@ -174,6 +175,12 @@ function saveFixture(url, args, response) {
   })
 }
 
+function ignoredUrl(url) {
+  return CONFIGURATION.ignoreUrls.some(function (urlToIgnore) {
+    return url.match(urlToIgnore)
+  })
+}
+
 // Log each call that was made so tests can verify
 var allCalled = []
 
@@ -181,7 +188,10 @@ function fetchVCR(url, args) {
   // Try to load the response from the fixture.
   // Then, if a fixture was not found, either fetch it for reals or error (depending on the VCR_MODE)
   const promise = new Promise(function (resolve, reject) {
-    if (CONFIGURATION.mode === 'record') {
+    if (ignoredUrl(url)) {
+      debug(url, 'this url is ignored by configuration')
+      fetchImpl(url, args).then(resolve).catch(reject)
+    } else if (CONFIGURATION.mode === 'record') {
       // Perform the fetch, save the response, and then yield the original response
       fetchImpl(url, args).then(function (response) {
         saveFixture(url, args, response).then(resolve).catch(reject)
@@ -231,6 +241,7 @@ function fetchVCR(url, args) {
 fetchVCR.configure = function (config) {
   CONFIGURATION.mode = VCR_MODE || config.mode
   CONFIGURATION.fixturePath = config.fixturePath || CONFIGURATION.fixturePath
+  CONFIGURATION.ignoreUrls = config.ignoreUrls || CONFIGURATION.ignoreUrls
   if (config.headerBlacklist) {
     CONFIGURATION.headerBlacklist = []
     config.headerBlacklist.forEach(function (key) {

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,16 @@ import fetchVCR from '../lib/index'
 test.before(t => {
   fetchVCR.configure({
     mode: 'playback',
-    fixturePath: __dirname + '/_fixtures'
+    fixturePath: __dirname + '/_fixtures',
+    ignoreUrls: [/.+ignore=true($|.+)/i]
+  })
+})
+
+test('ignores urls in ignoreUrls', t => {
+  return fetchVCR('https://test.com?ignore=true')
+  .then(response => {
+    return response.text()
+    .then(text => t.pass())
   })
 })
 


### PR DESCRIPTION
Adding `ignoreUrls` configuration to ignore some URLs based on regular expressions.

This helps when trying test certain urls without them going through fetch-vcr