### PR TITLE
Add Typescript declaration file

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,18 @@
+declare module 'fetch-vcr' {
+  function fetchVCR(url: string, args: object): Promise<any>;
+
+  interface Config {
+    mode?: 'playback' | 'cache' | 'record' | 'erase';
+    fixturePath?: string;
+    ignoreUrls?: string[];
+    headerBlacklist?: string[]
+  }
+  namespace fetchVCR {
+    function configure(config: Config): void;
+    function loadFile(root: string, filename: string): Promise<string>;
+    function saveFile(root: string, filename: string, buffer: string): Promise<'fetch-saved'>;
+    function getCalled(): void;
+    function clearCalled(): void;
+  }
+  export default fetchVCR;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "fetch-vcr",
   "description": "Stop mocking HTTP Requests. Just record and then play them back",
   "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "scripts": {
     "pretest": "./script/clean-for-test",
     "test": "ava",


### PR DESCRIPTION
This is my first try at a [Typescript declaration file](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html), which is necessary for Typescript support. I'm sure these definitions are incomplete and can be improved, but I figured that something was better than nothing. Can you take a look, and let me know if this seems reasonable?