### PR TITLE
Support node-fetch's Request class in fetchVCR

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -188,7 +188,12 @@ function ignoredUrl(url) {
 // Log each call that was made so tests can verify
 var allCalled = []
 
-function fetchVCR(url, args) {
+function fetchVCR(urlOrReq, args) {
+  let url = urlOrReq
+  if (typeof url !== 'string') {
+    url = url.url
+  }
+
   // Try to load the response from the fixture.
   // Then, if a fixture was not found, either fetch it for reals or error (depending on the VCR_MODE)
   const promise = new Promise(function (resolve, reject) {

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 import test from 'ava'
+import nodefetch from 'node-fetch'
 import assert from 'assert'
 import fetchVCR from '../lib/index'
 
@@ -99,4 +100,12 @@ test.cb('runs in jsdom', t => {
       window.fetch = fetchVCR
     }
   })
+})
+
+test('can use node-fetch.Request', t => {
+  return fetchVCR(new nodefetch.Request('https://archive.cnx.org/contents/9a1df55a-b167-4736-b5ad-15d996704270%403.2.json'))
+    .then(response => {
+      return response.json()
+        .then(text => t.pass())
+    })
 })


### PR DESCRIPTION
Came across this when using `fetch-vcr` in a project that uses node-fetch's `Request` object under the hood. This is a tiny patch to make that request object work with `fetch-vcr`.

May potentially have something to do with #5 as well.